### PR TITLE
Handle WebView popup windows

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
-        android:theme="@style/Theme.Rebrickable">   <!-- ← add this -->
+        android:theme="@style/Theme.Rebrickable">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/rebrickable/MainActivity.kt
+++ b/app/src/main/java/com/example/rebrickable/MainActivity.kt
@@ -136,14 +136,14 @@ class MainActivity : AppCompatActivity() {
 
 
         webView.webChromeClient = object : WebChromeClient() {
-//            override fun onCreateWindow(
-//                view: WebView?, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message?
-//            ): Boolean {
-//                val transport = resultMsg?.obj as? WebView.WebViewTransport ?: return false
-//                transport.webView = webView
-//                resultMsg.sendToTarget()
-//                return true
-//            }
+            override fun onCreateWindow(
+                view: WebView?, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message?
+            ): Boolean {
+                val transport = resultMsg?.obj as? WebView.WebViewTransport ?: return false
+                transport.webView = webView
+                resultMsg.sendToTarget()
+                return true
+            }
 
             override fun onShowFileChooser(
                 webView: WebView?, filePathCallback: ValueCallback<Array<Uri>>?,


### PR DESCRIPTION
## Summary
- clean up AndroidManifest theme declaration
- allow the WebView to handle links that request a new window by overriding `onCreateWindow`

## Testing
- `sh gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e62a34188321aefe1e0f24981832