### PR TITLE
Handle deep links and pin shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,13 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="www.rebrickable.com" />
+                <data android:scheme="https" android:host="rebrickable.com" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/rebrickable/MainActivity.kt
+++ b/app/src/main/java/com/example/rebrickable/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.content.pm.ShortcutInfo
+import android.content.pm.ShortcutManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
@@ -15,6 +17,7 @@ import android.os.Bundle
 import android.os.Message
 import android.os.Handler
 import android.os.Looper
+import android.graphics.drawable.Icon
 import android.webkit.CookieManager
 import android.webkit.DownloadListener
 import android.webkit.ValueCallback
@@ -47,7 +50,8 @@ class MainActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())
     private val showShareRunnable = Runnable { shareBtn.show() }
 
-    private val startUrl = "https://www.rebrickable.com/"
+    private val defaultUrl = "https://www.rebrickable.com/"
+    private var startUrl = defaultUrl
 
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
     private val filePickerLauncher = registerForActivityResult(
@@ -101,6 +105,8 @@ class MainActivity : AppCompatActivity() {
             handler.removeCallbacks(showShareRunnable)
             handler.postDelayed(showShareRunnable, 1000)
         }
+
+        ensurePinnedShortcut()
 
         if ((applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
             WebView.setWebContentsDebuggingEnabled(true)
@@ -224,7 +230,7 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
-        if (savedInstanceState == null) loadOrShowOffline(startUrl)
+        if (savedInstanceState == null) handleIntent(intent)
         else webView.restoreState(savedInstanceState)
 
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
@@ -237,6 +243,36 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         })
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent?) {
+        val url = intent?.dataString
+        startUrl = url ?: defaultUrl
+        loadOrShowOffline(startUrl)
+    }
+
+    private fun ensurePinnedShortcut() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val prefs = getSharedPreferences("prefs", Context.MODE_PRIVATE)
+            if (!prefs.getBoolean("shortcut_pinned", false)) {
+                val sm = getSystemService(ShortcutManager::class.java)
+                if (sm.isRequestPinShortcutSupported) {
+                    val shortcut = ShortcutInfo.Builder(this, "rebrickable")
+                        .setShortLabel(getString(R.string.app_name))
+                        .setLongLabel(getString(R.string.app_name))
+                        .setIcon(Icon.createWithResource(this, R.mipmap.ic_launcher))
+                        .setIntent(Intent(Intent.ACTION_VIEW, Uri.parse(defaultUrl)).setClass(this, MainActivity::class.java))
+                        .build()
+                    sm.requestPinShortcut(shortcut, null)
+                    prefs.edit().putBoolean("shortcut_pinned", true).apply()
+                }
+            }
+        }
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary
- open rebrickable.com links directly in the app
- request a home screen shortcut on first launch

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982bdf04248321bda59fe9fea2ebd3